### PR TITLE
Add CORS for HttpApi

### DIFF
--- a/tests/unit/commands/local/lib/test_sam_api_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_api_provider.py
@@ -1298,6 +1298,455 @@ class TestSamCors(TestCase):
         self.assertEqual(provider.api.cors, cors)
 
 
+class TestSamHttpApiCors(TestCase):
+    def test_provider_parse_cors_with_unresolved_intrinsic(self):
+        template = {
+            "Resources": {
+                "TestApi": {
+                    "Type": "AWS::Serverless::HttpApi",
+                    "Properties": {
+                        "StageName": "Prod",
+                        "CorsConfiguration": {"AllowOrigins": {"Fn:Sub": "Some string to sub"}},
+                        "DefinitionBody": {
+                            "paths": {
+                                "/path2": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "type": "aws_proxy",
+                                            "uri": {
+                                                "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31"
+                                                "/functions/${NoApiEventFunction.Arn}/invocations"
+                                            },
+                                            "responses": {},
+                                        }
+                                    }
+                                },
+                                "/path": {
+                                    "get": {
+                                        "x-amazon-apigateway-integration": {
+                                            "type": "aws_proxy",
+                                            "uri": {
+                                                "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31"
+                                                "/functions/${NoApiEventFunction.Arn}/invocations"
+                                            },
+                                            "responses": {},
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                    },
+                }
+            }
+        }
+
+        provider = ApiProvider(template)
+
+        routes = provider.routes
+        cors = Cors(
+            allow_origin=None,
+            allow_methods=",".join(sorted(["GET", "DELETE", "PUT", "POST", "HEAD", "OPTIONS", "PATCH"])),
+        )
+        route1 = Route(path="/path2", methods=["POST", "OPTIONS"], function_name="NoApiEventFunction")
+        route2 = Route(path="/path", methods=["GET", "OPTIONS"], function_name="NoApiEventFunction")
+
+        self.assertEqual(len(routes), 2)
+        self.assertIn(route1, routes)
+        self.assertIn(route2, routes)
+        self.assertEqual(provider.api.cors, cors)
+
+    def test_provider_parse_cors_true(self):
+        template = {
+            "Resources": {
+                "TestApi": {
+                    "Type": "AWS::Serverless::HttpApi",
+                    "Properties": {
+                        "StageName": "Prod",
+                        "CorsConfiguration": True,
+                        "DefinitionBody": {
+                            "paths": {
+                                "/path2": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "type": "aws_proxy",
+                                            "uri": {
+                                                "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31"
+                                                "/functions/${NoApiEventFunction.Arn}/invocations"
+                                            },
+                                            "responses": {},
+                                        }
+                                    }
+                                },
+                                "/path": {
+                                    "get": {
+                                        "x-amazon-apigateway-integration": {
+                                            "type": "aws_proxy",
+                                            "uri": {
+                                                "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31"
+                                                "/functions/${NoApiEventFunction.Arn}/invocations"
+                                            },
+                                            "responses": {},
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                    },
+                }
+            }
+        }
+
+        provider = ApiProvider(template)
+
+        routes = provider.routes
+        cors = Cors(
+            allow_origin="*",
+            allow_methods=",".join(sorted(["GET", "DELETE", "PUT", "POST", "HEAD", "OPTIONS", "PATCH"])),
+        )
+        route1 = Route(path="/path2", methods=["POST", "OPTIONS"], function_name="NoApiEventFunction")
+        route2 = Route(path="/path", methods=["GET", "OPTIONS"], function_name="NoApiEventFunction")
+
+        self.assertEqual(len(routes), 2)
+        self.assertIn(route1, routes)
+        self.assertIn(route2, routes)
+        self.assertEqual(provider.api.cors, cors)
+
+    def test_provider_parse_cors_false(self):
+        template = {
+            "Resources": {
+                "TestApi": {
+                    "Type": "AWS::Serverless::HttpApi",
+                    "Properties": {
+                        "StageName": "Prod",
+                        "CorsConfiguration": False,
+                        "DefinitionBody": {
+                            "paths": {
+                                "/path2": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "type": "aws_proxy",
+                                            "uri": {
+                                                "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31"
+                                                "/functions/${NoApiEventFunction.Arn}/invocations"
+                                            },
+                                            "responses": {},
+                                        }
+                                    }
+                                },
+                                "/path": {
+                                    "get": {
+                                        "x-amazon-apigateway-integration": {
+                                            "type": "aws_proxy",
+                                            "uri": {
+                                                "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31"
+                                                "/functions/${NoApiEventFunction.Arn}/invocations"
+                                            },
+                                            "responses": {},
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                    },
+                }
+            }
+        }
+
+        provider = ApiProvider(template)
+
+        routes = provider.routes
+        cors = None
+        route1 = Route(path="/path2", methods=["POST"], function_name="NoApiEventFunction")
+        route2 = Route(path="/path", methods=["GET"], function_name="NoApiEventFunction")
+
+        self.assertEqual(len(routes), 2)
+        self.assertIn(route1, routes)
+        self.assertIn(route2, routes)
+        self.assertEqual(provider.api.cors, cors)
+
+    def test_provider_parse_cors_dict(self):
+        template = {
+            "Resources": {
+                "TestApi": {
+                    "Type": "AWS::Serverless::HttpApi",
+                    "Properties": {
+                        "StageName": "Prod",
+                        "CorsConfiguration": {
+                            "AllowMethods": ["POST", "GET"],
+                            "AllowOrigins": ["*"],
+                            "AllowHeaders": ["Upgrade-Insecure-Requests"],
+                            "MaxAge": 600,
+                        },
+                        "DefinitionBody": {
+                            "paths": {
+                                "/path2": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "type": "aws_proxy",
+                                            "uri": {
+                                                "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31"
+                                                "/functions/${NoApiEventFunction.Arn}/invocations"
+                                            },
+                                            "responses": {},
+                                        }
+                                    }
+                                },
+                                "/path": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "type": "aws_proxy",
+                                            "uri": {
+                                                "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31"
+                                                "/functions/${NoApiEventFunction.Arn}/invocations"
+                                            },
+                                            "responses": {},
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                    },
+                }
+            }
+        }
+
+        provider = ApiProvider(template)
+
+        routes = provider.routes
+        cors = Cors(
+            allow_origin="*",
+            allow_methods=",".join(sorted(["POST", "GET", "OPTIONS"])),
+            allow_headers="Upgrade-Insecure-Requests",
+            max_age=600,
+        )
+        route1 = Route(path="/path2", methods=["POST", "OPTIONS"], function_name="NoApiEventFunction")
+        route2 = Route(path="/path", methods=["POST", "OPTIONS"], function_name="NoApiEventFunction")
+
+        self.assertEqual(len(routes), 2)
+        self.assertIn(route1, routes)
+        self.assertIn(route2, routes)
+        self.assertEqual(provider.api.cors, cors)
+
+    def test_provider_parse_cors_dict_star_allow(self):
+        template = {
+            "Resources": {
+                "TestApi": {
+                    "Type": "AWS::Serverless::HttpApi",
+                    "Properties": {
+                        "StageName": "Prod",
+                        "CorsConfiguration": {
+                            "AllowMethods": ["*"],
+                            "AllowOrigins": ["*"],
+                            "AllowHeaders": ["Upgrade-Insecure-Requests"],
+                            "MaxAge": 600,
+                        },
+                        "DefinitionBody": {
+                            "paths": {
+                                "/path2": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "type": "aws_proxy",
+                                            "uri": {
+                                                "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31"
+                                                "/functions/${NoApiEventFunction.Arn}/invocations"
+                                            },
+                                            "responses": {},
+                                        }
+                                    }
+                                },
+                                "/path": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "type": "aws_proxy",
+                                            "uri": {
+                                                "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31"
+                                                "/functions/${NoApiEventFunction.Arn}/invocations"
+                                            },
+                                            "responses": {},
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                    },
+                }
+            }
+        }
+
+        provider = ApiProvider(template)
+
+        routes = provider.routes
+        cors = Cors(
+            allow_origin="*",
+            allow_methods=",".join(sorted(Route.ANY_HTTP_METHODS)),
+            allow_headers="Upgrade-Insecure-Requests",
+            max_age=600,
+        )
+        route1 = Route(path="/path2", methods=["POST", "OPTIONS"], function_name="NoApiEventFunction")
+        route2 = Route(path="/path", methods=["POST", "OPTIONS"], function_name="NoApiEventFunction")
+
+        self.assertEqual(len(routes), 2)
+        self.assertIn(route1, routes)
+        self.assertIn(route2, routes)
+        self.assertEqual(provider.api.cors, cors)
+
+    def test_invalid_cors_dict_allow_methods(self):
+        template = {
+            "Resources": {
+                "TestApi": {
+                    "Type": "AWS::Serverless::HttpApi",
+                    "Properties": {
+                        "StageName": "Prod",
+                        "CorsConfiguration": {
+                            "AllowMethods": ["GET", "INVALID_METHOD"],
+                            "AllowOrigins": ["*"],
+                            "AllowHeaders": ["Upgrade-Insecure-Requests"],
+                            "MaxAge": 600,
+                        },
+                        "DefinitionBody": {
+                            "paths": {
+                                "/path2": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "type": "aws_proxy",
+                                            "uri": {
+                                                "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31"
+                                                "/functions/${NoApiEventFunction.Arn}/invocations"
+                                            },
+                                            "responses": {},
+                                        }
+                                    }
+                                },
+                                "/path": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "type": "aws_proxy",
+                                            "uri": {
+                                                "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31"
+                                                "/functions/${NoApiEventFunction.Arn}/invocations"
+                                            },
+                                            "responses": {},
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                    },
+                }
+            }
+        }
+        with self.assertRaises(
+            InvalidSamDocumentException, msg="ApiProvider should fail for Invalid Cors Allow method"
+        ):
+            ApiProvider(template)
+
+    def test_default_cors_dict_prop(self):
+        template = {
+            "Resources": {
+                "TestApi": {
+                    "Type": "AWS::Serverless::HttpApi",
+                    "Properties": {
+                        "StageName": "Prod",
+                        "CorsConfiguration": {"AllowOrigins": ["www.domain.com"]},
+                        "DefinitionBody": {
+                            "paths": {
+                                "/path2": {
+                                    "get": {
+                                        "x-amazon-apigateway-integration": {
+                                            "httpMethod": "POST",
+                                            "type": "aws_proxy",
+                                            "uri": {
+                                                "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31"
+                                                "/functions/${NoApiEventFunction.Arn}/invocations"
+                                            },
+                                            "responses": {},
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                    },
+                }
+            }
+        }
+
+        provider = ApiProvider(template)
+
+        routes = provider.routes
+        cors = Cors(allow_origin="www.domain.com", allow_methods=",".join(sorted(Route.ANY_HTTP_METHODS)))
+        route1 = Route(path="/path2", methods=["GET", "OPTIONS"], function_name="NoApiEventFunction")
+        self.assertEqual(len(routes), 1)
+        self.assertIn(route1, routes)
+        self.assertEqual(provider.api.cors, cors)
+
+    def test_global_cors(self):
+        template = {
+            "Globals": {
+                "HttpApi": {
+                    "CorsConfiguration": {
+                        "AllowMethods": ["GET"],
+                        "AllowOrigins": ["*"],
+                        "AllowHeaders": ["Upgrade-Insecure-Requests"],
+                        "MaxAge": 600,
+                    }
+                }
+            },
+            "Resources": {
+                "TestApi": {
+                    "Type": "AWS::Serverless::HttpApi",
+                    "Properties": {
+                        "StageName": "Prod",
+                        "DefinitionBody": {
+                            "paths": {
+                                "/path2": {
+                                    "get": {
+                                        "x-amazon-apigateway-integration": {
+                                            "type": "aws_proxy",
+                                            "uri": {
+                                                "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31"
+                                                "/functions/${NoApiEventFunction.Arn}/invocations"
+                                            },
+                                            "responses": {},
+                                        }
+                                    }
+                                },
+                                "/path": {
+                                    "get": {
+                                        "x-amazon-apigateway-integration": {
+                                            "type": "aws_proxy",
+                                            "uri": {
+                                                "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31"
+                                                "/functions/${NoApiEventFunction.Arn}/invocations"
+                                            },
+                                            "responses": {},
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                    },
+                }
+            },
+        }
+
+        provider = ApiProvider(template)
+
+        routes = provider.routes
+        cors = Cors(
+            allow_origin="*",
+            allow_headers="Upgrade-Insecure-Requests",
+            allow_methods=",".join(["GET", "OPTIONS"]),
+            max_age=600,
+        )
+        route1 = Route(path="/path2", methods=["GET", "OPTIONS"], function_name="NoApiEventFunction")
+        route2 = Route(path="/path", methods=["GET", "OPTIONS"], function_name="NoApiEventFunction")
+
+        self.assertEqual(len(routes), 2)
+        self.assertIn(route1, routes)
+        self.assertIn(route2, routes)
+        self.assertEqual(provider.api.cors, cors)
+
+
 def make_swagger(routes, binary_media_types=None):
     """
     Given a list of API configurations named tuples, returns a Swagger document


### PR DESCRIPTION
I'd like to apologise in advance.
Because this is first pull request for OSS in my life, and the sentence may be strange because I don't usually use English.

*Issue #, if available:* #1641

*Why is this change necessary?*
This changes is necessary in enable to `CORS` on `HttpApi`.

*How does it address the issue?*
I tried the [temporary solution](https://github.com/awslabs/aws-sam-cli/pull/1942#issuecomment-644063266).  It is very nice!!
But, I noticed that the CORS settings are not reflected.

This is example.
```template.yaml
HttpApi:
  Type: AWS::Serverless::HttpApi
  Properties:
    CorsConfiguration:
      AllowOrigins:
      - "*"
      AllowHeaders:
      - Authorization
      AllowMethods:
      - GET
      - POST
      - PUT
      - OPTIONS
```

I expected 
```OPTIONS Response Header
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET, POST, PUT, OPTIONS
Access-Control-Allow-Headers: Authorization, Content-Type
```
but, I got only this.
```
Access-Control-Allow-Methods: DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT
```


This issue occurs because of the difference between [HttpApiCorsConfiguration](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-httpapi-httpapicorsconfiguration.html) and [CorsConfiguration](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-api-corsconfiguration.html).

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*
No

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
