### PR TITLE
Support for payloadFormatVersion

### DIFF
--- a/samcli/commands/local/lib/swagger/parser.py
+++ b/samcli/commands/local/lib/swagger/parser.py
@@ -84,9 +84,37 @@ class SwaggerParser:
                 if method.lower() == self._ANY_METHOD_EXTENSION_KEY:
                     # Convert to a more commonly used method notation
                     method = self._ANY_METHOD
-                route = Route(function_name, full_path, methods=[method])
+                payload_format_version = self._get_payload_format_version(method_config)
+                route = Route(function_name, full_path, methods=[method], payload_format_version=payload_format_version)
                 result.append(route)
         return result
+
+    def _get_integration(self, method_config):
+        """
+        Get Integration defined in the method configuration.
+        Integration configuration is defined under the special "x-amazon-apigateway-integration" key. We care only
+        about Lambda integrations, which are of type aws_proxy, and ignore the rest.
+
+        Parameters
+        ----------
+        method_config : dict
+            Dictionary containing the method configuration which might contain integration settings
+
+        Returns
+        -------
+        dict or None
+            integration, if possible. None, if not.
+        """
+        if not isinstance(method_config, dict) or self._INTEGRATION_KEY not in method_config:
+            return None
+
+        integration = method_config[self._INTEGRATION_KEY]
+
+        if integration and isinstance(integration, dict) and integration.get("type") == IntegrationType.aws_proxy.value:
+            # Integration must be "aws_proxy" otherwise we don't care about it
+            return integration
+
+        return None
 
     def _get_integration_function_name(self, method_config):
         """
@@ -106,13 +134,28 @@ class SwaggerParser:
         string or None
             Lambda function name, if possible. None, if not.
         """
-        if not isinstance(method_config, dict) or self._INTEGRATION_KEY not in method_config:
+        integration = self._get_integration(method_config)
+        if integration is None:
             return None
 
-        integration = method_config[self._INTEGRATION_KEY]
+        return LambdaUri.get_function_name(integration.get("uri"))
 
-        if integration and isinstance(integration, dict) and integration.get("type") == IntegrationType.aws_proxy.value:
-            # Integration must be "aws_proxy" otherwise we don't care about it
-            return LambdaUri.get_function_name(integration.get("uri"))
+    def _get_payload_format_version(self, method_config):
+        """
+        Get the "payloadFormatVersion" from the Integration defined in the method configuration.
 
-        return None
+        Parameters
+        ----------
+        method_config : dict
+            Dictionary containing the method configuration which might contain integration settings
+
+        Returns
+        -------
+        string or None
+            Payload format version, if exists. None, if not.
+        """
+        integration = self._get_integration(method_config)
+        if integration is None:
+            return None
+
+        return integration.get("payloadFormatVersion")

--- a/samcli/lib/providers/api_collector.py
+++ b/samcli/lib/providers/api_collector.py
@@ -140,14 +140,14 @@ class ApiCollector:
     @staticmethod
     def dedupe_function_routes(routes):
         """
-        Remove duplicate routes that have the same function_name and method
+         Remove duplicate routes that have the same function_name and method
 
-        route: list(Route)
-            List of Routes
+         route: list(Route)
+             List of Routes
 
-       Return
-       -------
-       A list of routes without duplicate routes with the same function_name and method
+        Return
+        -------
+        A list of routes without duplicate routes with the same function_name and method
         """
         grouped_routes = {}
 
@@ -159,7 +159,11 @@ class ApiCollector:
                 methods += config.methods
             sorted_methods = sorted(methods)
             grouped_routes[key] = Route(
-                function_name=route.function_name, path=route.path, methods=sorted_methods, event_type=route.event_type
+                function_name=route.function_name,
+                path=route.path,
+                methods=sorted_methods,
+                event_type=route.event_type,
+                payload_format_version=route.payload_format_version,
             )
         return list(grouped_routes.values())
 

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -36,18 +36,21 @@ class Route:
     HTTP = "HttpApi"
     ANY_HTTP_METHODS = ["GET", "DELETE", "PUT", "POST", "HEAD", "OPTIONS", "PATCH"]
 
-    def __init__(self, function_name, path, methods, event_type=API):
+    def __init__(self, function_name, path, methods, event_type=API, payload_format_version=None):
         """
         Creates an ApiGatewayRoute
 
         :param list(str) methods: http method
         :param function_name: Name of the Lambda function this API is connected to
         :param str path: Path off the base url
+        :param str event_type: Type of the event. "Api" or "HttpApi"
+        :param str payload_format_version: version of payload format
         """
         self.methods = self.normalize_method(methods)
         self.function_name = function_name
         self.path = path
         self.event_type = event_type
+        self.payload_format_version = payload_format_version
 
     def __eq__(self, other):
         return (
@@ -198,7 +201,7 @@ class LocalApigwService(BaseLocalService):
             return self.service_response("", headers, 200)
 
         try:
-            if route.event_type == Route.HTTP:
+            if route.event_type == Route.HTTP and route.payload_format_version in [None, "2.0"]:
                 event = self._construct_event_http(
                     request,
                     self.port,
@@ -340,7 +343,7 @@ class LocalApigwService(BaseLocalService):
 
     @staticmethod
     def _invalid_apig_response_keys(output):
-        allowable = {"statusCode", "body", "headers", "multiValueHeaders", "isBase64Encoded"}
+        allowable = {"statusCode", "body", "headers", "multiValueHeaders", "isBase64Encoded", "cookies"}
         invalid_keys = output.keys() - allowable
         return invalid_keys
 

--- a/tests/unit/commands/local/lib/swagger/test_parser.py
+++ b/tests/unit/commands/local/lib/swagger/test_parser.py
@@ -89,6 +89,43 @@ class TestSwaggerParser_get_apis(TestCase):
 
         self.assertEqual(expected, result)
 
+    def test_payload_format_version(self):
+        function_name = "myfunction"
+        swagger = {
+            "paths": {
+                "/path1": {
+                    "get": {
+                        "x-amazon-apigateway-integration": {
+                            "type": "aws_proxy",
+                            "uri": "someuri",
+                            "payloadFormatVersion": "1.0",
+                        }
+                    }
+                },
+                "/path2": {
+                    "get": {
+                        "x-amazon-apigateway-integration": {
+                            "type": "aws_proxy",
+                            "uri": "someuri",
+                            "payloadFormatVersion": "2.0",
+                        }
+                    }
+                },
+            }
+        }
+
+        parser = SwaggerParser(swagger)
+        parser._get_integration_function_name = Mock()
+        parser._get_integration_function_name.return_value = function_name
+
+        expected = [
+            Route(path="/path1", methods=["get"], function_name=function_name, payload_format_version="1.0"),
+            Route(path="/path2", methods=["get"], function_name=function_name, payload_format_version="2.0"),
+        ]
+        result = parser.get_routes()
+
+        self.assertEqual(expected, result)
+
     @parameterized.expand(
         [
             param("empty swagger", {}),


### PR DESCRIPTION
*Issue #, if available:* #1641

*Why is this change necessary?*
This changes is necessary in order to make `HttpApi` event type work with `sam local start-api`.

*How does it address the issue?*
Extract the "payloadFormatVersion" of the OpenAPI document. If "payloadFormatVersion" is not specified, "2.0" will be used.

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*
No

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
